### PR TITLE
Remove unnecessary data block and tidy up outputs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   getexamples:
-    if: github.event.repository.name != 'terraform-azurerm-avm-template'
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'    
     runs-on: ubuntu-latest
     outputs:
       examples: ${{ steps.getexamples.outputs.examples }}
@@ -26,8 +26,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   testexamples:
-    if: github.event.repository.name != 'terraform-azurerm-avm-template'
-    runs-on: [ self-hosted, 1ES.Pool=a4ff77c708a54eb23884e4b7b9e50c72a771beb4 ]
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'    
+    runs-on: ubuntu-latest
     needs: getexamples
     environment: test
     env:
@@ -36,24 +36,24 @@ jobs:
     strategy:
       matrix:
         example: ${{ fromJson(needs.getexamples.outputs.examples) }}
-      fail-fast: false
+      max-parallel: 5
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - uses: actions/checkout@v4
+
+      - uses: Azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Test example
-        shell: bash
-        run: |
-          set -e
-          az login --identity --username $MSI_ID > /dev/null
-          export ARM_SUBSCRIPTION_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .id')
-          export ARM_TENANT_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .tenantId')
-          export ARM_CLIENT_ID=$(az identity list | jq -r --arg MSI_ID "$MSI_ID" '.[] | select(.principalId == $MSI_ID) | .clientId')
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e ARM_USE_MSI=true mcr.microsoft.com/azterraform:latest make test-example
+        uses: Azure/terraform-azurerm-avm-template/.github/actions/e2e-testexamples@main
+        with:
+          example: ${{ matrix.example }}
 
   # This job is only run when all the previous jobs are successful.
   # We can use it for PR validation to ensure all examples have completed.
   testexamplescomplete:
-    if: github.event.repository.name != 'terraform-azurerm-avm-template'
     runs-on: ubuntu-latest
     needs: testexamples
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   getexamples:
-    if: github.event.repository.name != 'terraform-azurerm-avm-template'    
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'
     runs-on: ubuntu-latest
     outputs:
       examples: ${{ steps.getexamples.outputs.examples }}
@@ -26,8 +26,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   testexamples:
-    if: github.event.repository.name != 'terraform-azurerm-avm-template'    
-    runs-on: ubuntu-latest
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'
+    runs-on: [ self-hosted, 1ES.Pool=a4ff77c708a54eb23884e4b7b9e50c72a771beb4 ]
     needs: getexamples
     environment: test
     env:
@@ -36,25 +36,26 @@ jobs:
     strategy:
       matrix:
         example: ${{ fromJson(needs.getexamples.outputs.examples) }}
-      max-parallel: 5
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: Azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Test example
-        uses: Azure/terraform-azurerm-avm-template/.github/actions/e2e-testexamples@main
-        with:
-          example: ${{ matrix.example }}
+        shell: bash
+        run: |
+          set -e
+          az login --identity --username $MSI_ID > /dev/null
+          export ARM_SUBSCRIPTION_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .id')
+          export ARM_TENANT_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .tenantId')
+          export ARM_CLIENT_ID=$(az identity list | jq -r --arg MSI_ID "$MSI_ID" '.[] | select(.principalId == $MSI_ID) | .clientId')
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e ARM_USE_MSI=true mcr.microsoft.com/azterraform:latest make test-example
 
   # This job is only run when all the previous jobs are successful.
   # We can use it for PR validation to ensure all examples have completed.
   testexamplescomplete:
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'
     runs-on: ubuntu-latest
     needs: testexamples
     steps:
       - run: echo "All tests passed"
+  

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Default: `null`
 ### <a name="input_dapr_components"></a> [dapr\_components](#input\_dapr\_components)
 
 Description: - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
-
 - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
 - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
 - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
@@ -99,20 +98,17 @@ Description: - `component_type` - (Required) The Dapr Component Type. For exampl
 
 ---
 `metadata` block supports the following:
-
 - `name` - (Required) The name of the Metadata configuration item.
 - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
 - `value` - (Optional) The value for this metadata configuration item.
 
 ---
 `secret` block supports the following:
-
 - `name` - (Required) The Secret name.
 - `value` - (Required) The value for this secret.
 
 ---
 `timeouts` block supports the following:
-
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
@@ -304,15 +300,13 @@ Default: `{}`
 
 ### <a name="input_storages"></a> [storages](#input\_storages)
 
-Description:
-- `access_key` - (Required) The Storage Account Access Key.
+Description: - `access_key` - (Required) The Storage Account Access Key.
 - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
 - `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 
 ---
 `timeouts` block supports the following:
-
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The following resources are used by this module:
 - [azurerm_resource_group_template_deployment.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group_template_deployment) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [random_id.telem](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
-- [azapi_resource.this_environment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azurerm_resource_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -91,6 +90,7 @@ Default: `null`
 ### <a name="input_dapr_components"></a> [dapr\_components](#input\_dapr\_components)
 
 Description: - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
+
 - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
 - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
 - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
@@ -99,17 +99,20 @@ Description: - `component_type` - (Required) The Dapr Component Type. For exampl
 
 ---
 `metadata` block supports the following:
+
 - `name` - (Required) The name of the Metadata configuration item.
 - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
 - `value` - (Optional) The value for this metadata configuration item.
 
 ---
 `secret` block supports the following:
+
 - `name` - (Required) The Secret name.
 - `value` - (Required) The value for this secret.
 
 ---
 `timeouts` block supports the following:
+
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
@@ -181,8 +184,8 @@ Default: `{}`
 
 ### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
 
-Description: This variable controls whether or not telemetry is enabled for the module.
-For more information see <https://aka.ms/avm/telemetryinfo>.
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
 If it is set to false, then no telemetry will be collected.
 
 Type: `bool`
@@ -191,8 +194,8 @@ Default: `true`
 
 ### <a name="input_infrastructure_resource_group_name"></a> [infrastructure\_resource\_group\_name](#input\_infrastructure\_resource\_group\_name)
 
-Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.
-If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.
+Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.   
+If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.  
 If not specified, then one will be generated automatically, in the form `ME_<app_managed_environment_name>_<resource_group>_<location>`.
 
 Type: `string`
@@ -301,13 +304,15 @@ Default: `{}`
 
 ### <a name="input_storages"></a> [storages](#input\_storages)
 
-Description: - `access_key` - (Required) The Storage Account Access Key.
+Description:
+- `access_key` - (Required) The Storage Account Access Key.
 - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
 - `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 
 ---
 `timeouts` block supports the following:
+
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
@@ -370,8 +375,8 @@ Default: `false`
 
 ### <a name="input_workload_profile"></a> [workload\_profile](#input\_workload\_profile)
 
-Description:
-This lists the workload profiles that will be configured for the Managed Environment.
+Description:   
+This lists the workload profiles that will be configured for the Managed Environment.  
 This is in addition to the default Consumpion Plan workload profile.
 
  - `maximum_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.

--- a/_header.md
+++ b/_header.md
@@ -2,5 +2,4 @@
 
 Module to deploy Container Apps Managed Environments in Azure.
 
-> [!WARNING]
-> Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. A module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>
+-> Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. A module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>

--- a/examples/workload_profile_internal/output.tf
+++ b/examples/workload_profile_internal/output.tf
@@ -1,4 +1,5 @@
 output "app_environment" {
   description = "The outputs for the managed environment, this allows outputs to be inspected in the CI run."
   value       = module.managedenvironment.resource
+  sensitive   = true
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,8 @@
 locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 
-  workload_profile_outputs = jsondecode(azapi_resource.this_environment.output.body).properties.workloadProfiles != null ? [
-    for wp in jsondecode(azapi_resource.this_environment.output.body).properties.workloadProfiles : merge(
+  workload_profile_outputs = jsondecode(azapi_resource.this_environment.body).properties.workloadProfiles != null ? [
+    for wp in jsondecode(azapi_resource.this_environment.body).properties.workloadProfiles : merge(
       {
         name                  = wp.name
         workload_profile_type = wp.workloadProfileType

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,8 @@
 locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 
-  workload_profile_outputs = jsondecode(azapi_resource.this_environment.output).properties.workloadProfiles != null ? [
-    for wp in jsondecode(azapi_resource.this_environment.output).properties.workloadProfiles : merge(
+  workload_profile_outputs = jsondecode(azapi_resource.this_environment.output.body).properties.workloadProfiles != null ? [
+    for wp in jsondecode(azapi_resource.this_environment.output.body).properties.workloadProfiles : merge(
       {
         name                  = wp.name
         workload_profile_type = wp.workloadProfileType

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,8 @@
 locals {
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 
-  workload_profile_outputs = jsondecode(data.azapi_resource.this_environment.output).properties.workloadProfiles != null ? [
-    for wp in jsondecode(data.azapi_resource.this_environment.output).properties.workloadProfiles : merge(
+  workload_profile_outputs = jsondecode(azapi_resource.this_environment.output).properties.workloadProfiles != null ? [
+    for wp in jsondecode(azapi_resource.this_environment.output).properties.workloadProfiles : merge(
       {
         name                  = wp.name
         workload_profile_type = wp.workloadProfileType

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.1.0"
+    "module_version": "0.1.1"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,19 @@ resource "azapi_resource" "this_environment" {
       zoneRedundant = var.zone_redundancy_enabled
     }
   })
-  location                  = coalesce(var.location, data.azurerm_resource_group.parent.location)
-  name                      = var.name
-  parent_id                 = data.azurerm_resource_group.parent.id
-  response_export_values    = ["*"]
+  location  = coalesce(var.location, data.azurerm_resource_group.parent.location)
+  name      = var.name
+  parent_id = data.azurerm_resource_group.parent.id
+  response_export_values = [
+    "properties.customDomainConfiguration",
+    "properties.daprAIInstrumentationKey",
+    "properties.defaultDomain",
+    "properties.infrastructureResourceGroup",
+    "properties.peerAuthentication",
+    "properties.staticIp",
+    "properties.vnetConfiguration",
+    "properties.workloadProfiles",
+  ]
   schema_validation_enabled = true
   tags                      = var.tags
   dynamic "timeouts" {

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "azapi_resource" "this_environment" {
   location                  = coalesce(var.location, data.azurerm_resource_group.parent.location)
   name                      = var.name
   parent_id                 = data.azurerm_resource_group.parent.id
+  response_export_values    = ["*"]
   schema_validation_enabled = false
   tags                      = var.tags
   dynamic "timeouts" {

--- a/main.tf
+++ b/main.tf
@@ -38,11 +38,20 @@ resource "azapi_resource" "this_environment" {
       zoneRedundant = var.zone_redundancy_enabled
     }
   })
-  location                  = coalesce(var.location, data.azurerm_resource_group.parent.location)
-  name                      = var.name
-  parent_id                 = data.azurerm_resource_group.parent.id
-  response_export_values    = ["*"]
-  schema_validation_enabled = false
+  location  = coalesce(var.location, data.azurerm_resource_group.parent.location)
+  name      = var.name
+  parent_id = data.azurerm_resource_group.parent.id
+  response_export_values = [
+    "customDomainConfiguration",
+    "daprAIInstrumentationKey",
+    "defaultDomain",
+    "infrastructureResourceGroup",
+    "peerAuthentication",
+    "staticIp",
+    "vnetConfiguration",
+    "workloadProfiles",
+  ]
+  schema_validation_enabled = true
   tags                      = var.tags
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]

--- a/main.tf
+++ b/main.tf
@@ -42,14 +42,14 @@ resource "azapi_resource" "this_environment" {
   name      = var.name
   parent_id = data.azurerm_resource_group.parent.id
   response_export_values = [
-    "customDomainConfiguration",
-    "daprAIInstrumentationKey",
-    "defaultDomain",
-    "infrastructureResourceGroup",
-    "peerAuthentication",
-    "staticIp",
-    "vnetConfiguration",
-    "workloadProfiles",
+    "properties.customDomainConfiguration",
+    "properties.daprAIInstrumentationKey",
+    "properties.defaultDomain",
+    "properties.infrastructureResourceGroup",
+    "properties.peerAuthentication",
+    "properties.staticIp",
+    "properties.vnetConfiguration",
+    "properties.workloadProfiles",
   ]
   schema_validation_enabled = true
   tags                      = var.tags

--- a/main.tf
+++ b/main.tf
@@ -54,13 +54,6 @@ resource "azapi_resource" "this_environment" {
   }
 }
 
-data "azapi_resource" "this_environment" {
-  type                   = "Microsoft.App/managedEnvironments@2023-05-01"
-  name                   = azapi_resource.this_environment.name
-  parent_id              = data.azurerm_resource_group.parent.id
-  response_export_values = ["*"]
-}
-
 resource "azurerm_management_lock" "this" {
   count = var.lock.kind != "None" ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -38,19 +38,10 @@ resource "azapi_resource" "this_environment" {
       zoneRedundant = var.zone_redundancy_enabled
     }
   })
-  location  = coalesce(var.location, data.azurerm_resource_group.parent.location)
-  name      = var.name
-  parent_id = data.azurerm_resource_group.parent.id
-  response_export_values = [
-    "properties.customDomainConfiguration",
-    "properties.daprAIInstrumentationKey",
-    "properties.defaultDomain",
-    "properties.infrastructureResourceGroup",
-    "properties.peerAuthentication",
-    "properties.staticIp",
-    "properties.vnetConfiguration",
-    "properties.workloadProfiles",
-  ]
+  location                  = coalesce(var.location, data.azurerm_resource_group.parent.location)
+  name                      = var.name
+  parent_id                 = data.azurerm_resource_group.parent.id
+  response_export_values    = ["*"]
   schema_validation_enabled = true
   tags                      = var.tags
   dynamic "timeouts" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,7 +31,6 @@ output "resource" {
     infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
     mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
   }
-  sensitive = true
 }
 
 output "id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,7 @@ output "resource" {
     infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
     mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
   }
+  sensitive = true
 }
 
 output "id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,26 +10,26 @@ output "resource" {
     location            = azapi_resource.this_environment.location
 
     # outputs provided by the AzureRM provider
-    dapr_application_insights_connection_string = try(jsondecode(azapi_resource.this_environment.output.body).properties.daprAIConnectionString, null)
-    infrastructure_subnet_id                    = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.infrastructureSubnetId, null)
-    internal_load_balancer_enabled              = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.internal, null)
-    log_analytics_workspace_id                  = try(jsondecode(azapi_resource.this_environment.output.body).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
+    dapr_application_insights_connection_string = try(jsondecode(azapi_resource.this_environment.body).properties.daprAIConnectionString, null)
+    infrastructure_subnet_id                    = try(jsondecode(azapi_resource.this_environment.body).properties.vnetConfiguration.infrastructureSubnetId, null)
+    internal_load_balancer_enabled              = try(jsondecode(azapi_resource.this_environment.body).properties.vnetConfiguration.internal, null)
+    log_analytics_workspace_id                  = try(jsondecode(azapi_resource.this_environment.body).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
     tags                                        = try(azapi_resource.this_environment.tags, null)
     workload_profiles                           = local.workload_profile_outputs
-    zone_redundancy_enabled                     = try(jsondecode(azapi_resource.this_environment.output.body).properties.zoneRedundant, null)
+    zone_redundancy_enabled                     = try(jsondecode(azapi_resource.this_environment.body).properties.zoneRedundant, null)
 
     # outputs provided by the AzureRM provider known after apply
-    default_domain                   = jsondecode(azapi_resource.this_environment.output.body).properties.defaultDomain
-    docker_bridge_cidr               = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.dockerBridgeCidr, null)
-    platform_reserved_cidr           = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.platformReservedCidr, null)
-    platform_reserved_dns_ip_address = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.platformReservedDnsIP, null)
-    static_ip_address                = jsondecode(azapi_resource.this_environment.output.body).properties.staticIp
+    default_domain                   = jsondecode(azapi_resource.this_environment.output).properties.defaultDomain
+    docker_bridge_cidr               = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.dockerBridgeCidr, null)
+    platform_reserved_cidr           = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedCidr, null)
+    platform_reserved_dns_ip_address = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedDnsIP, null)
+    static_ip_address                = jsondecode(azapi_resource.this_environment.output).properties.staticIp
 
     # additional outputs not yet supported by the AzureRM provider
-    custom_domain_verification_id          = try(jsondecode(azapi_resource.this_environment.output.body).properties.customDomainConfiguration.customDomainVerificationId, null)
-    dapr_azure_monitor_instrumentation_key = try(jsondecode(azapi_resource.this_environment.output.body).properties.daprAIInstrumentationKey, null)
-    infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output.body).properties.infrastructureResourceGroup, null)
-    mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output.body).properties.peerAuthentication.mtls.enabled, false)
+    custom_domain_verification_id          = try(jsondecode(azapi_resource.this_environment.output).properties.customDomainConfiguration.customDomainVerificationId, null)
+    dapr_azure_monitor_instrumentation_key = try(jsondecode(azapi_resource.this_environment.output).properties.daprAIInstrumentationKey, null)
+    infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
+    mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,29 +7,29 @@ output "resource" {
     id                  = azapi_resource.this_environment.id
     name                = azapi_resource.this_environment.name
     resource_group_name = data.azurerm_resource_group.parent.name
-    location            = jsondecode(data.azapi_resource.this_environment.output).location
+    location            = azapi_resource.this_environment.location
 
     # outputs provided by the AzureRM provider
-    dapr_application_insights_connection_string = try(jsondecode(data.azapi_resource.this_environment.output).properties.daprAIConnectionString, null)
-    infrastructure_subnet_id                    = try(jsondecode(data.azapi_resource.this_environment.output).properties.vnetConfiguration.infrastructureSubnetId, null)
-    internal_load_balancer_enabled              = try(jsondecode(data.azapi_resource.this_environment.output).properties.vnetConfiguration.internal, null)
-    log_analytics_workspace_id                  = try(jsondecode(data.azapi_resource.this_environment.output).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
+    dapr_application_insights_connection_string = try(jsondecode(azapi_resource.this_environment.output).properties.daprAIConnectionString, null)
+    infrastructure_subnet_id                    = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.infrastructureSubnetId, null)
+    internal_load_balancer_enabled              = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.internal, null)
+    log_analytics_workspace_id                  = try(jsondecode(azapi_resource.this_environment.output).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
     tags                                        = try(azapi_resource.this_environment.tags, null)
     workload_profiles                           = local.workload_profile_outputs
-    zone_redundancy_enabled                     = try(jsondecode(data.azapi_resource.this_environment.output).properties.zoneRedundant, null)
+    zone_redundancy_enabled                     = try(jsondecode(azapi_resource.this_environment.output).properties.zoneRedundant, null)
 
     # outputs provided by the AzureRM provider known after apply
-    default_domain                   = jsondecode(data.azapi_resource.this_environment.output).properties.defaultDomain
-    docker_bridge_cidr               = try(jsondecode(data.azapi_resource.this_environment.output).properties.vnetConfiguration.dockerBridgeCidr, null)
-    platform_reserved_cidr           = try(jsondecode(data.azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedCidr, null)
-    platform_reserved_dns_ip_address = try(jsondecode(data.azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedDnsIP, null)
-    static_ip_address                = jsondecode(data.azapi_resource.this_environment.output).properties.staticIp
+    default_domain                   = jsondecode(azapi_resource.this_environment.output).properties.defaultDomain
+    docker_bridge_cidr               = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.dockerBridgeCidr, null)
+    platform_reserved_cidr           = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedCidr, null)
+    platform_reserved_dns_ip_address = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedDnsIP, null)
+    static_ip_address                = jsondecode(azapi_resource.this_environment.output).properties.staticIp
 
     # additional outputs not yet supported by the AzureRM provider
-    custom_domain_verification_id          = try(jsondecode(data.azapi_resource.this_environment.output).properties.customDomainConfiguration.customDomainVerificationId, null)
-    dapr_azure_monitor_instrumentation_key = try(jsondecode(data.azapi_resource.this_environment.output).properties.daprAIInstrumentationKey, null)
-    infrastructure_resource_group          = try(jsondecode(data.azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
-    mtls_enabled                           = try(jsondecode(data.azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
+    custom_domain_verification_id          = try(jsondecode(azapi_resource.this_environment.output).properties.customDomainConfiguration.customDomainVerificationId, null)
+    dapr_azure_monitor_instrumentation_key = try(jsondecode(azapi_resource.this_environment.output).properties.daprAIInstrumentationKey, null)
+    infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
+    mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,26 +10,26 @@ output "resource" {
     location            = azapi_resource.this_environment.location
 
     # outputs provided by the AzureRM provider
-    dapr_application_insights_connection_string = try(jsondecode(azapi_resource.this_environment.output).properties.daprAIConnectionString, null)
-    infrastructure_subnet_id                    = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.infrastructureSubnetId, null)
-    internal_load_balancer_enabled              = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.internal, null)
-    log_analytics_workspace_id                  = try(jsondecode(azapi_resource.this_environment.output).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
+    dapr_application_insights_connection_string = try(jsondecode(azapi_resource.this_environment.output.body).properties.daprAIConnectionString, null)
+    infrastructure_subnet_id                    = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.infrastructureSubnetId, null)
+    internal_load_balancer_enabled              = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.internal, null)
+    log_analytics_workspace_id                  = try(jsondecode(azapi_resource.this_environment.output.body).properties.appLogsConfiguration.logAnalyticsConfiguration.customerId, null)
     tags                                        = try(azapi_resource.this_environment.tags, null)
     workload_profiles                           = local.workload_profile_outputs
-    zone_redundancy_enabled                     = try(jsondecode(azapi_resource.this_environment.output).properties.zoneRedundant, null)
+    zone_redundancy_enabled                     = try(jsondecode(azapi_resource.this_environment.output.body).properties.zoneRedundant, null)
 
     # outputs provided by the AzureRM provider known after apply
-    default_domain                   = jsondecode(azapi_resource.this_environment.output).properties.defaultDomain
-    docker_bridge_cidr               = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.dockerBridgeCidr, null)
-    platform_reserved_cidr           = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedCidr, null)
-    platform_reserved_dns_ip_address = try(jsondecode(azapi_resource.this_environment.output).properties.vnetConfiguration.platformReservedDnsIP, null)
-    static_ip_address                = jsondecode(azapi_resource.this_environment.output).properties.staticIp
+    default_domain                   = jsondecode(azapi_resource.this_environment.output.body).properties.defaultDomain
+    docker_bridge_cidr               = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.dockerBridgeCidr, null)
+    platform_reserved_cidr           = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.platformReservedCidr, null)
+    platform_reserved_dns_ip_address = try(jsondecode(azapi_resource.this_environment.output.body).properties.vnetConfiguration.platformReservedDnsIP, null)
+    static_ip_address                = jsondecode(azapi_resource.this_environment.output.body).properties.staticIp
 
     # additional outputs not yet supported by the AzureRM provider
-    custom_domain_verification_id          = try(jsondecode(azapi_resource.this_environment.output).properties.customDomainConfiguration.customDomainVerificationId, null)
-    dapr_azure_monitor_instrumentation_key = try(jsondecode(azapi_resource.this_environment.output).properties.daprAIInstrumentationKey, null)
-    infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output).properties.infrastructureResourceGroup, null)
-    mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output).properties.peerAuthentication.mtls.enabled, false)
+    custom_domain_verification_id          = try(jsondecode(azapi_resource.this_environment.output.body).properties.customDomainConfiguration.customDomainVerificationId, null)
+    dapr_azure_monitor_instrumentation_key = try(jsondecode(azapi_resource.this_environment.output.body).properties.daprAIInstrumentationKey, null)
+    infrastructure_resource_group          = try(jsondecode(azapi_resource.this_environment.output.body).properties.infrastructureResourceGroup, null)
+    mtls_enabled                           = try(jsondecode(azapi_resource.this_environment.output.body).properties.peerAuthentication.mtls.enabled, false)
   }
 }
 

--- a/variable.storage.tf
+++ b/variable.storage.tf
@@ -13,7 +13,6 @@ variable "storages" {
   }))
   default     = {}
   description = <<-EOT
-
  - `access_key` - (Required) The Storage Account Access Key.
  - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
  - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
@@ -21,7 +20,6 @@ variable "storages" {
 
  ---
  `timeouts` block supports the following:
-
  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.

--- a/variable.storage.tf
+++ b/variable.storage.tf
@@ -13,6 +13,7 @@ variable "storages" {
   }))
   default     = {}
   description = <<-EOT
+
  - `access_key` - (Required) The Storage Account Access Key.
  - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
  - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
@@ -20,10 +21,12 @@ variable "storages" {
 
  ---
  `timeouts` block supports the following:
+
  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
  - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Storage.
+
 EOT
   nullable    = false
 }

--- a/variables.dapr_component.tf
+++ b/variables.dapr_component.tf
@@ -25,7 +25,6 @@ variable "dapr_components" {
   default     = {}
   description = <<-EOT
  - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
- 
  - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
  - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
  - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
@@ -34,20 +33,17 @@ variable "dapr_components" {
 
  ---
  `metadata` block supports the following:
- 
  - `name` - (Required) The name of the Metadata configuration item.
  - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
  - `value` - (Optional) The value for this metadata configuration item.
 
  ---
  `secret` block supports the following:
-
  - `name` - (Required) The Secret name.
  - `value` - (Required) The value for this secret.
 
  ---
  `timeouts` block supports the following:
-
  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.

--- a/variables.dapr_component.tf
+++ b/variables.dapr_component.tf
@@ -25,6 +25,7 @@ variable "dapr_components" {
   default     = {}
   description = <<-EOT
  - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
+ 
  - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
  - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
  - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
@@ -33,17 +34,20 @@ variable "dapr_components" {
 
  ---
  `metadata` block supports the following:
+ 
  - `name` - (Required) The name of the Metadata configuration item.
  - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
  - `value` - (Optional) The value for this metadata configuration item.
 
  ---
  `secret` block supports the following:
+
  - `name` - (Required) The Secret name.
  - `value` - (Required) The value for this secret.
 
  ---
  `timeouts` block supports the following:
+
  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,7 @@ For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
+
 variable "infrastructure_subnet_id" {
   type        = string
   default     = null


### PR DESCRIPTION
The primary purpose of this change is to remove the azapi data block within main.tf, which is unnecessary

Instead, output properties are fetched either from the body or outputs via response_export_values.

Additionally, schema validation has been enabled, 

There are no functional changes in this PR.

From my repo:

![image](https://github.com/Azure/terraform-azurerm-avm-res-app-managedenvironment/assets/3146590/4f9197f0-c4da-4e41-9e25-29d5626b3f96)