### PR TITLE
Fix workload profile setting

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
 
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
+
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
 ## Providers
@@ -25,6 +27,8 @@ The following providers are used by this module:
 - <a name="provider_azapi"></a> [azapi](#provider\_azapi) (~> 1.13)
 
 - <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 3.71)
+
+- <a name="provider_modtm"></a> [modtm](#provider\_modtm) (~> 0.3)
 
 - <a name="provider_random"></a> [random](#provider\_random) (~> 3.5)
 
@@ -37,10 +41,12 @@ The following resources are used by this module:
 - [azapi_resource.this_environment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
-- [azurerm_resource_group_template_deployment.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group_template_deployment) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
-- [random_id.telem](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
+- [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
+- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [azurerm_resource_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
+- [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/locals.tf
+++ b/locals.tf
@@ -37,6 +37,11 @@ locals {
       share_name   = sv.body.properties.azureFile.shareName
     }
   }
+  # these workload_profile_* locals are used to mimic the behaviour of the azurerm provider
+  workload_profile_consumption_enabled = contains([
+    for wp in var.workload_profile :
+    wp.name == "Consumption" && wp.workload_profile_type == "Consumption"
+  ], true)
   workload_profile_outputs = azapi_resource.this_environment.body.properties.workloadProfiles != null ? [
     for wp in azapi_resource.this_environment.body.properties.workloadProfiles : merge(
       {
@@ -50,16 +55,4 @@ locals {
       } : {}
     )
   ] : null
-  workload_profiles = setsubtract(var.workload_profile, [{
-    name                = "Consumption"
-    workloadProfileType = "Consumption"
-  }])
-  # these workload_profile_* locals are used to mimic the behaviour of the azurerm provider
-  workload_profiles_consumption_enabled = contains(
-    var.workload_profile,
-    {
-      name                = "Consumption"
-      workloadProfileType = "Consumption"
-    }
-  )
 }

--- a/main.dapr_component.tf
+++ b/main.dapr_component.tf
@@ -35,6 +35,7 @@ resource "azapi_resource" "dapr_components" {
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -18,6 +18,7 @@ resource "azapi_resource" "storages" {
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -3,7 +3,8 @@ data "azurerm_client_config" "telemetry" {
 }
 
 data "modtm_module_source" "telemetry" {
-  count       = var.enable_telemetry ? 1 : 0
+  count = var.enable_telemetry ? 1 : 0
+
   module_path = path.module
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,12 +28,19 @@ resource "azapi_resource" "this_environment" {
         "internal"               = var.internal_load_balancer_enabled
         "infrastructureSubnetId" = var.infrastructure_subnet_id
       } : null
-      workloadProfiles = local.workload_profiles_consumption_enabled ? setunion([
+      workloadProfiles = local.workload_profile_consumption_enabled ? setunion([
         {
           name                = "Consumption"
           workloadProfileType = "Consumption"
         }],
-        local.workload_profiles
+        [for wp in var.workload_profile :
+          {
+            name                = wp.name
+            workloadProfileType = wp.workload_profile_type
+            minimumCount        = wp.minimum_count
+            maximumCount        = wp.maximum_count
+          } if wp.workload_profile_type != "Consumption"
+        ]
       ) : null
       zoneRedundant = var.zone_redundancy_enabled
     }
@@ -56,6 +63,7 @@ resource "azapi_resource" "this_environment" {
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete
@@ -100,18 +108,21 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
 
   dynamic "enabled_log" {
     for_each = each.value.log_categories
+
     content {
       category = enabled_log.value
     }
   }
   dynamic "enabled_log" {
     for_each = each.value.log_groups
+
     content {
       category_group = enabled_log.value
     }
   }
   dynamic "metric" {
     for_each = each.value.metric_categories
+
     content {
       category = metric.value
     }

--- a/terraform.tf
+++ b/terraform.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"


### PR DESCRIPTION
## Description

Setting a workload profile wasn't working, because the check for consumption profile to set `workload_profiles_consumption_enabled` didn't account for the fact that the workload_profile variable includes also the max/min count with default values. So I fixed this part. Also fixed is the part that sets the `workloadProfiles` for the azapi resource to use the correct format.

The rest of the changes are white-space changes from running the avm pre-commit and adding the modtm provider that was needed for the module to work, because of previous commits in main the branch.

avm pr-check fails because some more changes are needed, I think because of updates to interface specs.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
