### PR TITLE
feat: specify log analytics via resource key rather than using shared keys

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
 
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
+
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
 ## Providers
@@ -25,6 +27,8 @@ The following providers are used by this module:
 - <a name="provider_azapi"></a> [azapi](#provider\_azapi) (~> 1.13)
 
 - <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 3.71)
+
+- <a name="provider_modtm"></a> [modtm](#provider\_modtm) (~> 0.3)
 
 - <a name="provider_random"></a> [random](#provider\_random) (~> 3.5)
 
@@ -37,15 +41,24 @@ The following resources are used by this module:
 - [azapi_resource.this_environment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
-- [azurerm_resource_group_template_deployment.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group_template_deployment) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
-- [random_id.telem](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
+- [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
+- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [azapi_resource_action.shared_keys](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_action) (data source)
+- [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [azurerm_resource_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
+- [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
 
 The following input variables are required:
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: Azure region where the resource should be deployed.
+
+Type: `string`
 
 ### <a name="input_name"></a> [name](#input\_name)
 
@@ -213,14 +226,6 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_location"></a> [location](#input\_location)
-
-Description: Azure region where the resource should be deployed.  If null, the location will be inferred from the resource group location.
-
-Type: `string`
-
-Default: `null`
-
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description: Controls the Resource Lock configuration for this resource. The following properties can be specified:
@@ -239,14 +244,6 @@ object({
 
 Default: `null`
 
-### <a name="input_log_analytics_workspace_customer_id"></a> [log\_analytics\_workspace\_customer\_id](#input\_log\_analytics\_workspace\_customer\_id)
-
-Description: The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to.
-
-Type: `string`
-
-Default: `null`
-
 ### <a name="input_log_analytics_workspace_destination"></a> [log\_analytics\_workspace\_destination](#input\_log\_analytics\_workspace\_destination)
 
 Description: Destination for Log Analytics (options: 'log-analytics', 'azuremonitor', 'none').
@@ -255,9 +252,9 @@ Type: `string`
 
 Default: `"log-analytics"`
 
-### <a name="input_log_analytics_workspace_primary_shared_key"></a> [log\_analytics\_workspace\_primary\_shared\_key](#input\_log\_analytics\_workspace\_primary\_shared\_key)
+### <a name="input_log_analytics_workspace_resource_id"></a> [log\_analytics\_workspace\_resource\_id](#input\_log\_analytics\_workspace\_resource\_id)
 
-Description: Primary shared key for Log Analytics.
+Description: The resource ID for the Log Analytics Workspace to link this Container Apps Managed Environment to.
 
 Type: `string`
 
@@ -273,15 +270,16 @@ Default: `false`
 
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
-Description: A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+Description: A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
 - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
 - `principal_id` - The ID of the principal to assign the role to.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+- `description` - (Optional) The description of the role assignment.
+- `skip_service_principal_aad_check` - (Optional) If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+- `condition` - (Optional) The condition which will be used to scope the role assignment.
+- `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
 - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id which contains a Managed Identity. Changing this forces a new resource to be created. This field is only used in cross-tenant scenario.
+- `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
 
 > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
 
@@ -296,6 +294,7 @@ map(object({
     condition                              = optional(string, null)
     condition_version                      = optional(string, null)
     delegated_managed_identity_resource_id = optional(string, null)
+    principal_type                         = optional(string, null)
   }))
 ```
 
@@ -406,11 +405,15 @@ Description: The ID of the resource.
 
 ### <a name="output_name"></a> [name](#output\_name)
 
-Description: The name of the resource
+Description: The name of the container apps management environment resource.
 
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: The Container Apps Managed Environment resource.
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the container apps management environment resource.
 
 ### <a name="output_storages"></a> [storages](#output\_storages)
 

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/examples/dapr_component/README.md
+++ b/examples/dapr_component/README.md
@@ -49,8 +49,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   dapr_components = {
     "my-dapr-component" = {

--- a/examples/dapr_component/main.tf
+++ b/examples/dapr_component/main.tf
@@ -43,8 +43,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   dapr_components = {
     "my-dapr-component" = {

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -49,8 +49,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -43,8 +43,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false

--- a/examples/storage_share/README.md
+++ b/examples/storage_share/README.md
@@ -63,8 +63,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   storages = {
     "mycontainerappstorage" = {

--- a/examples/storage_share/main.tf
+++ b/examples/storage_share/main.tf
@@ -57,8 +57,7 @@ module "managedenvironment" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 
   storages = {
     "mycontainerappstorage" = {

--- a/examples/workload_profile/README.md
+++ b/examples/workload_profile/README.md
@@ -75,8 +75,7 @@ module "managedenvironment" {
   }]
   zone_redundancy_enabled = true
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 }
 ```
 

--- a/examples/workload_profile/main.tf
+++ b/examples/workload_profile/main.tf
@@ -65,6 +65,5 @@ module "managedenvironment" {
   }]
   zone_redundancy_enabled = true
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 }

--- a/examples/workload_profile_internal/README.md
+++ b/examples/workload_profile_internal/README.md
@@ -73,8 +73,7 @@ module "managedenvironment" {
   internal_load_balancer_enabled     = true
   infrastructure_resource_group_name = "rg-managed-${module.naming.container_app_environment.name_unique}"
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 }
 ```
 

--- a/examples/workload_profile_internal/main.tf
+++ b/examples/workload_profile_internal/main.tf
@@ -67,6 +67,5 @@ module "managedenvironment" {
   internal_load_balancer_enabled     = true
   infrastructure_resource_group_name = "rg-managed-${module.naming.container_app_environment.name_unique}"
 
-  log_analytics_workspace_customer_id        = azurerm_log_analytics_workspace.this.workspace_id
-  log_analytics_workspace_primary_shared_key = azurerm_log_analytics_workspace.this.primary_shared_key
+  log_analytics_workspace_resource_id = azurerm_log_analytics_workspace.this.id
 }

--- a/main.dapr_component.tf
+++ b/main.dapr_component.tf
@@ -35,6 +35,7 @@ resource "azapi_resource" "dapr_components" {
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -18,6 +18,7 @@ resource "azapi_resource" "storages" {
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -3,7 +3,8 @@ data "azurerm_client_config" "telemetry" {
 }
 
 data "modtm_module_source" "telemetry" {
-  count       = var.enable_telemetry ? 1 : 0
+  count = var.enable_telemetry ? 1 : 0
+
   module_path = path.module
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "id" {
 }
 
 output "name" {
-  description = "The name of the resource"
+  description = "The name of the container apps management environment resource."
   value       = azapi_resource.this_environment.name
 }
 
@@ -43,6 +43,11 @@ output "resource" {
     infrastructure_resource_group          = try(azapi_resource.this_environment.output.properties.infrastructureResourceGroup, null)
     mtls_enabled                           = try(azapi_resource.this_environment.output.properties.peerAuthentication.mtls.enabled, false)
   }
+}
+
+output "resource_id" {
+  description = "The ID of the container apps management environment resource."
+  value       = azapi_resource.this_environment.id
 }
 
 output "storages" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "location" {
+  type        = string
+  description = "Azure region where the resource should be deployed."
+  nullable    = false
+}
+
 variable "name" {
   type        = string
   description = "The name of the Container Apps Managed Environment."
@@ -106,12 +112,6 @@ variable "internal_load_balancer_enabled" {
   description = "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified."
 }
 
-variable "location" {
-  type        = string
-  default     = null
-  description = "Azure region where the resource should be deployed.  If null, the location will be inferred from the resource group location."
-}
-
 variable "lock" {
   type = object({
     kind = string
@@ -131,12 +131,6 @@ DESCRIPTION
   }
 }
 
-variable "log_analytics_workspace_customer_id" {
-  type        = string
-  default     = null
-  description = "The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to."
-}
-
 variable "log_analytics_workspace_destination" {
   type        = string
   default     = "log-analytics"
@@ -148,10 +142,10 @@ variable "log_analytics_workspace_destination" {
   }
 }
 
-variable "log_analytics_workspace_primary_shared_key" {
+variable "log_analytics_workspace_resource_id" {
   type        = string
   default     = null
-  description = "Primary shared key for Log Analytics."
+  description = "The resource ID for the Log Analytics Workspace to link this Container Apps Managed Environment to."
 }
 
 variable "peer_authentication_enabled" {
@@ -169,19 +163,21 @@ variable "role_assignments" {
     condition                              = optional(string, null)
     condition_version                      = optional(string, null)
     delegated_managed_identity_resource_id = optional(string, null)
+    principal_type                         = optional(string, null)
   }))
   default     = {}
   description = <<DESCRIPTION
-A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
 - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
 - `principal_id` - The ID of the principal to assign the role to.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+- `description` - (Optional) The description of the role assignment.
+- `skip_service_principal_aad_check` - (Optional) If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+- `condition` - (Optional) The condition which will be used to scope the role assignment.
+- `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
 - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id which contains a Managed Identity. Changing this forces a new resource to be created. This field is only used in cross-tenant scenario.
- 
+- `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+
 > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
 DESCRIPTION
   nullable    = false


### PR DESCRIPTION
## Description

This changes the mechanism to specify the log analytics workspace to use the LAW resource id rather than specifying the shared key.

Note this also includes lint fixes which are in the wp-fix branch, be best if that is folded first and this rebased. https://github.com/Azure/terraform-azurerm-avm-res-app-managedenvironment/pull/87

Closes #39
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [X] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
