### PR TITLE
move subresources into sub modules & linting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Description: The secrets output of the Dapr components.
 
 ### <a name="output_dapr_components"></a> [dapr\_components](#output\_dapr\_components)
 
-Description: A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr\_components resource.
+Description: A map of dapr components connected to this environment. The map key is the supplied input to var.dapr\_components. The map value is the azurerm-formatted version of the entire dapr\_components resource.
 
 ### <a name="output_default_domain"></a> [default\_domain](#output\_default\_domain)
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Default: `null`
 ### <a name="input_dapr_components"></a> [dapr\_components](#input\_dapr\_components)
 
 Description: - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
-
 - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
 - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
 - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
@@ -99,20 +98,17 @@ Description: - `component_type` - (Required) The Dapr Component Type. For exampl
 
 ---
 `metadata` block supports the following:
-
 - `name` - (Required) The name of the Metadata configuration item.
 - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
 - `value` - (Optional) The value for this metadata configuration item.
 
 ---
 `secret` block supports the following:
-
 - `name` - (Required) The Secret name.
 - `value` - (Required) The value for this secret.
 
 ---
 `timeouts` block supports the following:
-
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
@@ -193,7 +189,7 @@ Default: `true`
 
 ### <a name="input_infrastructure_resource_group_name"></a> [infrastructure\_resource\_group\_name](#input\_infrastructure\_resource\_group\_name)
 
-Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.
+Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.   
 If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.  
 If not specified, then one will be generated automatically, in the form `ME_<app_managed_environment_name>_<resource_group>_<location>`.
 
@@ -302,14 +298,12 @@ Default: `{}`
 ### <a name="input_storages"></a> [storages](#input\_storages)
 
 Description: - `access_key` - (Required) The Storage Account Access Key.
-
 - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
 - `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 
 ---
 `timeouts` block supports the following:
-
 - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
@@ -344,7 +338,6 @@ Default: `null`
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 
 Description: - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment.
-
 - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment.
 - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment.
 - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment.
@@ -363,14 +356,14 @@ Default: `null`
 
 ### <a name="input_workload_profile"></a> [workload\_profile](#input\_workload\_profile)
 
-Description:
+Description:   
 This lists the workload profiles that will be configured for the Managed Environment.  
 This is in addition to the default Consumpion Plan workload profile.
 
-- `maximum_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
-- `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.
-- `name` - (Required) The name of the workload profile.
-- `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
+ - `maximum_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
+ - `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.
+ - `name` - (Required) The name of the workload profile.
+ - `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.dapr_components](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
-- [azapi_resource.storages](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_environment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
@@ -394,15 +392,7 @@ The following outputs are exported:
 
 Description: The custom domain verification ID of the Container Apps Managed Environment.
 
-### <a name="output_dapr_component_metadata_secrets"></a> [dapr\_component\_metadata\_secrets](#output\_dapr\_component\_metadata\_secrets)
-
-Description: The metadata secrets output of the Dapr components.
-
-### <a name="output_dapr_component_secrets"></a> [dapr\_component\_secrets](#output\_dapr\_component\_secrets)
-
-Description: The secrets output of the Dapr components.
-
-### <a name="output_dapr_components"></a> [dapr\_components](#output\_dapr\_components)
+### <a name="output_dapr_component_resource_ids"></a> [dapr\_component\_resource\_ids](#output\_dapr\_component\_resource\_ids)
 
 Description: A map of dapr components connected to this environment. The map key is the supplied input to var.dapr\_components. The map value is the azurerm-formatted version of the entire dapr\_components resource.
 
@@ -446,17 +436,25 @@ Description: The ID of the container app management environment resource.
 
 Description: The static IP address of the Container Apps Managed Environment.
 
-### <a name="output_storage_access_keys"></a> [storage\_access\_keys](#output\_storage\_access\_keys)
-
-Description: The access key outputs of the storage resources.
-
-### <a name="output_storages"></a> [storages](#output\_storages)
+### <a name="output_storage_resource_ids"></a> [storage\_resource\_ids](#output\_storage\_resource\_ids)
 
 Description: A map of storage shares connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire storage shares resource.
 
 ## Modules
 
-No modules.
+The following Modules are called:
+
+### <a name="module_dapr_component"></a> [dapr\_component](#module\_dapr\_component)
+
+Source: ./modules/dapr_component
+
+Version:
+
+### <a name="module_storage"></a> [storage](#module\_storage)
+
+Source: ./modules/storage
+
+Version:
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/azurerm4_azapi2/README.md
+++ b/examples/azurerm4_azapi2/README.md
@@ -159,17 +159,9 @@ No optional inputs.
 
 The following outputs are exported:
 
-### <a name="output_dapr_component_metadata_secrets"></a> [dapr\_component\_metadata\_secrets](#output\_dapr\_component\_metadata\_secrets)
+### <a name="output_dapr_component_resource_ids"></a> [dapr\_component\_resource\_ids](#output\_dapr\_component\_resource\_ids)
 
-Description: The metadata secrets output of the Dapr components.
-
-### <a name="output_dapr_component_secrets"></a> [dapr\_component\_secrets](#output\_dapr\_component\_secrets)
-
-Description: The secrets output of the Dapr components.
-
-### <a name="output_dapr_components"></a> [dapr\_components](#output\_dapr\_components)
-
-Description: A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr\_components resource.
+Description: A map of dapr component resource IDs.
 
 ### <a name="output_default_domain"></a> [default\_domain](#output\_default\_domain)
 
@@ -211,13 +203,9 @@ Description: The resource ID of the Container Apps Managed Environment.
 
 Description: The static IP address of the Container Apps Managed Environment.
 
-### <a name="output_storages"></a> [storages](#output\_storages)
+### <a name="output_storage_resource_ids"></a> [storage\_resource\_ids](#output\_storage\_resource\_ids)
 
-Description: The storage of the Container Apps Managed Environment.
-
-### <a name="output_storages_access_keys"></a> [storages\_access\_keys](#output\_storages\_access\_keys)
-
-Description: The storage access keys for storage resources attached to the Container Apps Managed Environment.
+Description: A map of dapr component resource IDs.
 
 ## Modules
 

--- a/examples/azurerm4_azapi2/README.md
+++ b/examples/azurerm4_azapi2/README.md
@@ -7,6 +7,8 @@ This deploys the module with all the supported subcomponents using AzureRM v4 an
 terraform {
   required_version = ">= 1.8.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v2 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 2.0.0"

--- a/examples/azurerm4_azapi2/main.tf
+++ b/examples/azurerm4_azapi2/main.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.8.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v2 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 2.0.0"

--- a/examples/azurerm4_azapi2/output.tf
+++ b/examples/azurerm4_azapi2/output.tf
@@ -48,30 +48,12 @@ output "mtls_enabled" {
   value       = module.managedenvironment.mtls_enabled
 }
 
-output "dapr_components" {
-  description = "A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr_components resource."
-  value       = module.managedenvironment.dapr_components
+output "dapr_component_resource_ids" {
+  description = "A map of dapr component resource IDs."
+  value       = module.managedenvironment.dapr_component_resource_ids
 }
 
-output "dapr_component_metadata_secrets" {
-  description = "The metadata secrets output of the Dapr components."
-  value       = module.managedenvironment.dapr_component_metadata_secrets
-  sensitive   = true
-}
-
-output "dapr_component_secrets" {
-  description = "The secrets output of the Dapr components."
-  value       = module.managedenvironment.dapr_component_secrets
-  sensitive   = true
-}
-
-output "storages" {
-  description = "The storage of the Container Apps Managed Environment."
-  value       = module.managedenvironment.storages
-}
-
-output "storages_access_keys" {
-  description = "The storage access keys for storage resources attached to the Container Apps Managed Environment."
-  value       = module.managedenvironment.storage_access_keys
-  sensitive   = true
+output "storage_resource_ids" {
+  description = "A map of dapr component resource IDs."
+  value       = module.managedenvironment.storage_resource_ids
 }

--- a/examples/dapr_component/README.md
+++ b/examples/dapr_component/README.md
@@ -7,6 +7,12 @@ This deploys the module with a environment-scoped dapr component.
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.13, < 2.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0.0"
@@ -70,6 +76,8 @@ module "managedenvironment" {
 The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.7.0, < 4.0.0)
 

--- a/examples/dapr_component/README.md
+++ b/examples/dapr_component/README.md
@@ -68,6 +68,11 @@ module "managedenvironment" {
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false
 }
+
+moved {
+  to   = module.managedenvironment.module.dapr_component["my-dapr-component"].azapi_resource.this
+  from = module.managedenvironment.azapi_resource.dapr_components["my-dapr-component"]
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -101,17 +106,9 @@ No optional inputs.
 
 The following outputs are exported:
 
-### <a name="output_dapr_component_metadata_secrets"></a> [dapr\_component\_metadata\_secrets](#output\_dapr\_component\_metadata\_secrets)
+### <a name="output_dapr_component_resource_ids"></a> [dapr\_component\_resource\_ids](#output\_dapr\_component\_resource\_ids)
 
-Description: The metadata secrets output of the Dapr components.
-
-### <a name="output_dapr_component_secrets"></a> [dapr\_component\_secrets](#output\_dapr\_component\_secrets)
-
-Description: The secrets output of the Dapr components.
-
-### <a name="output_dapr_components"></a> [dapr\_components](#output\_dapr\_components)
-
-Description: A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr\_components resource.
+Description: A map of dapr component resource IDs.
 
 ## Modules
 

--- a/examples/dapr_component/main.tf
+++ b/examples/dapr_component/main.tf
@@ -62,3 +62,8 @@ module "managedenvironment" {
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false
 }
+
+moved {
+  to   = module.managedenvironment.module.dapr_component["my-dapr-component"].azapi_resource.this
+  from = module.managedenvironment.azapi_resource.dapr_components["my-dapr-component"]
+}

--- a/examples/dapr_component/main.tf
+++ b/examples/dapr_component/main.tf
@@ -1,6 +1,12 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.13, < 2.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0.0"

--- a/examples/dapr_component/output.tf
+++ b/examples/dapr_component/output.tf
@@ -1,16 +1,4 @@
-output "dapr_components" {
-  description = "A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr_components resource."
-  value       = module.managedenvironment.dapr_components
-}
-
-output "dapr_component_metadata_secrets" {
-  description = "The metadata secrets output of the Dapr components."
-  value       = module.managedenvironment.dapr_component_metadata_secrets
-  sensitive   = true
-}
-
-output "dapr_component_secrets" {
-  description = "The secrets output of the Dapr components."
-  value       = module.managedenvironment.dapr_component_secrets
-  sensitive   = true
+output "dapr_component_resource_ids" {
+  description = "A map of dapr component resource IDs."
+  value       = module.managedenvironment.dapr_component_resource_ids
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -7,6 +7,8 @@ This deploys the module in its simplest form.
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/storage_share/README.md
+++ b/examples/storage_share/README.md
@@ -122,7 +122,11 @@ No optional inputs.
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_storage_resource_ids"></a> [storage\_resource\_ids](#output\_storage\_resource\_ids)
+
+Description: A map of dapr component resource IDs.
 
 ## Modules
 

--- a/examples/storage_share/README.md
+++ b/examples/storage_share/README.md
@@ -84,6 +84,11 @@ module "managedenvironment" {
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false
 }
+
+moved {
+  from = module.managedenvironment.azapi_resource.storages["mycontainerappstorage"]
+  to   = module.managedenvironment.module.storage["mycontainerappstorage"].azapi_resource.this
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -117,15 +122,7 @@ No optional inputs.
 
 ## Outputs
 
-The following outputs are exported:
-
-### <a name="output_storages"></a> [storages](#output\_storages)
-
-Description: The storage of the Container Apps Managed Environment.
-
-### <a name="output_storages_access_keys"></a> [storages\_access\_keys](#output\_storages\_access\_keys)
-
-Description: The storage access keys for storage resources attached to the Container Apps Managed Environment.
+No outputs.
 
 ## Modules
 

--- a/examples/storage_share/README.md
+++ b/examples/storage_share/README.md
@@ -7,6 +7,8 @@ This deploys the module with Container App Environment storage.
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/storage_share/main.tf
+++ b/examples/storage_share/main.tf
@@ -78,3 +78,8 @@ module "managedenvironment" {
   # zone redundancy must be disabled unless we supply a subnet for vnet integration.
   zone_redundancy_enabled = false
 }
+
+moved {
+  from = module.managedenvironment.azapi_resource.storages["mycontainerappstorage"]
+  to   = module.managedenvironment.module.storage["mycontainerappstorage"].azapi_resource.this
+}

--- a/examples/storage_share/main.tf
+++ b/examples/storage_share/main.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/storage_share/output.tf
+++ b/examples/storage_share/output.tf
@@ -1,10 +1,1 @@
-output "storages" {
-  description = "The storage of the Container Apps Managed Environment."
-  value       = module.managedenvironment.storages
-}
 
-output "storages_access_keys" {
-  description = "The storage access keys for storage resources attached to the Container Apps Managed Environment."
-  value       = module.managedenvironment.storage_access_keys
-  sensitive   = true
-}

--- a/examples/storage_share/output.tf
+++ b/examples/storage_share/output.tf
@@ -1,1 +1,4 @@
-
+output "storage_resource_ids" {
+  description = "A map of dapr component resource IDs."
+  value       = module.managedenvironment.storage_resource_ids
+}

--- a/examples/workload_profile/README.md
+++ b/examples/workload_profile/README.md
@@ -11,6 +11,8 @@ This will create an additional resource group for platform managed resources tha
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/workload_profile/main.tf
+++ b/examples/workload_profile/main.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/workload_profile_internal/README.md
+++ b/examples/workload_profile_internal/README.md
@@ -7,6 +7,8 @@ This deploys a Container Apps Managed Environment using the consumption-based wo
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/examples/workload_profile_internal/main.tf
+++ b/examples/workload_profile_internal/main.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
+    # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = ">= 1.13, < 2.0.0"

--- a/locals.tf
+++ b/locals.tf
@@ -55,22 +55,9 @@ locals {
       share_name   = sv.body.properties.azureFile.shareName
     }
   }
-  # these workload_profile_* locals are used to mimic the behaviour of the azurerm provider
+  # this is used to mimic the behaviour of the azurerm provider
   workload_profile_consumption_enabled = contains([
     for wp in var.workload_profile :
     wp.name == "Consumption" && wp.workload_profile_type == "Consumption"
   ], true)
-  workload_profile_outputs = azapi_resource.this_environment.body.properties.workloadProfiles != null ? [
-    for wp in azapi_resource.this_environment.body.properties.workloadProfiles : merge(
-      {
-        name                  = wp.name
-        workload_profile_type = wp.workloadProfileType
-      },
-      # minimumCount and maximumCount are not applicable if the workloadProfileType is "Consumption"
-      wp.workloadProfileType != "Consumption" ? {
-        minimum_count = wp.minimumCount
-        maximum_count = wp.maximumCount
-      } : {}
-    )
-  ] : null
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,58 +1,15 @@
 locals {
-  dapr_component_metadata_secrets_output = {
-    for dk, dv in azapi_resource.dapr_components :
-    dk => dv.body.properties.metadata != null ? [
-      for item in dv.body.properties.metadata : {
-        value = item.value
-      }
-    ] : null
-  }
-  dapr_component_outputs = {
-    for dk, dv in azapi_resource.dapr_components :
+  dapr_component_resource_ids = {
+    for dk, dv in module.dapr_component :
     dk => {
-      id                     = dv.id
-      component_type         = dv.body.properties.componentType
-      ignore_errors          = dv.body.properties.ignoreErrors
-      init_timeout           = dv.body.properties.initTimeout
-      secret_store_component = dv.body.properties.secretStoreComponent
-      scopes                 = dv.body.properties.scopes
-      version                = dv.body.properties.version
-      metadata = dv.body.properties.metadata != null ? [
-        for item in dv.body.properties.metadata : {
-          name        = item.name
-          secret_name = item.secretRef
-        }
-      ] : null
-      secret = dv.body.properties.secrets != null ? [
-        for item in dv.body.properties.secrets : {
-          name                = item.name
-          identity            = item.identity
-          key_vault_secret_id = item.keyVaultUrl
-        }
-      ] : null
+      id = dv.resource_id
     }
   }
-  dapr_component_secrets_output = {
-    for dk, dv in azapi_resource.dapr_components :
-    dk => dv.body.properties.secrets != null ? [
-      for item in dv.body.properties.secrets : {
-        value = item.value
-      }
-    ] : null
-  }
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
-  # access keys are kept separate because they need to be marked as sensitive
-  storage_access_key_outputs = {
-    for sk, sv in azapi_resource.storages :
-    sk => sv.body.properties.azureFile.accountKey
-  }
-  storages_outputs = {
-    for sk, sv in azapi_resource.storages :
+  storage_resource_ids = {
+    for sk, sv in module.storage :
     sk => {
-      id           = sv.id
-      access_mode  = sv.body.properties.azureFile.accessMode
-      account_name = sv.body.properties.azureFile.accountName
-      share_name   = sv.body.properties.azureFile.shareName
+      id = sv.resource_id
     }
   }
   # this is used to mimic the behaviour of the azurerm provider

--- a/main.storage.tf
+++ b/main.storage.tf
@@ -1,28 +1,14 @@
-resource "azapi_resource" "storages" {
+module "storage" {
+  source   = "./modules/storage"
   for_each = var.storages
 
-  type = "Microsoft.App/managedEnvironments/storages@2023-05-01"
-  body = {
-    properties = {
-      azureFile = {
-        accessMode  = each.value.access_mode
-        accountKey  = each.value.access_key
-        accountName = each.value.account_name
-        shareName   = each.value.share_name
-      }
-    }
-  }
-  name                      = each.key
-  parent_id                 = azapi_resource.this_environment.id
-  schema_validation_enabled = true
+  name                = each.key
+  managed_environment = { resource_id = azapi_resource.this_environment.id }
 
-  dynamic "timeouts" {
-    for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+  access_key   = each.value.access_key
+  account_name = each.value.account_name
+  share_name   = each.value.share_name
+  access_mode  = each.value.access_mode
 
-    content {
-      create = timeouts.value.create
-      delete = timeouts.value.delete
-      read   = timeouts.value.read
-    }
-  }
+  timeouts = each.value.timeouts
 }

--- a/modules/.terraform-docs.yml
+++ b/modules/.terraform-docs.yml
@@ -1,0 +1,67 @@
+### To generate the output file to partially incorporate in the README.md,
+### Execute this command in the Terraform module's code folder:
+# terraform-docs -c .terraform-docs.yml .
+
+formatter: "markdown document" # this is required
+
+version: "~> 0.18"
+
+header-from: "_header.md"
+footer-from: "_footer.md"
+
+recursive:
+  enabled: false
+  path: modules
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  {{ .Header }}
+
+  <!-- markdownlint-disable MD033 -->
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Resources }}
+
+  <!-- markdownlint-disable MD013 -->
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Modules }}
+
+  {{ .Footer }}
+
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: false
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/modules/dapr_component/README.md
+++ b/modules/dapr_component/README.md
@@ -1,0 +1,180 @@
+<!-- BEGIN_TF_DOCS -->
+# Azure Container Apps Managed Environment Dapr Components Module
+
+This module is used to create Dapr Components for a Container Apps Environment.
+
+## Usage
+
+```terraform
+module "avm-res-app-managedenvironment-daprcomponent" {
+  source = "Azure/avm-res-app-managedenvironment/azurerm//modules/dapr_component"
+
+  managed_environment = {
+    resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.App/managedEnvironments/myEnv"
+  }
+
+  component_type = "state.azure.blobstorage"
+  version        = "v1"
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_azapi"></a> [azapi](#provider\_azapi) (>= 1.13, < 3)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.this](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_component_type"></a> [component\_type](#input\_component\_type)
+
+Description: The type of the Dapr component.
+
+Type: `string`
+
+### <a name="input_managed_environment"></a> [managed\_environment](#input\_managed\_environment)
+
+Description: The Dapr component resource.
+
+Type:
+
+```hcl
+object({
+    resource_id = string
+  })
+```
+
+### <a name="input_name"></a> [name](#input\_name)
+
+Description: The name of the Dapr component.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_dapr_component_version"></a> [dapr\_component\_version](#input\_dapr\_component\_version)
+
+Description: The version of the Dapr component.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_ignore_errors"></a> [ignore\_errors](#input\_ignore\_errors)
+
+Description: Whether to ignore errors for the Dapr component.
+
+Type: `bool`
+
+Default: `false`
+
+### <a name="input_init_timeout"></a> [init\_timeout](#input\_init\_timeout)
+
+Description: The initialization timeout for the Dapr component.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_metadata"></a> [metadata](#input\_metadata)
+
+Description: The metadata for the Dapr component.
+
+Type:
+
+```hcl
+list(object({
+    name        = string
+    secret_name = string
+    value       = string
+  }))
+```
+
+Default: `null`
+
+### <a name="input_scopes"></a> [scopes](#input\_scopes)
+
+Description: The scopes for the Dapr component.
+
+Type: `list(string)`
+
+Default: `[]`
+
+### <a name="input_secret"></a> [secret](#input\_secret)
+
+Description: The secrets for the Dapr component.
+
+Type:
+
+```hcl
+set(object({
+    # identity            = string
+    # key_vault_secret_id = string
+    name  = string
+    value = string
+  }))
+```
+
+Default: `null`
+
+### <a name="input_secret_store_component"></a> [secret\_store\_component](#input\_secret\_store\_component)
+
+Description: The secret store component for the Dapr component.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: The timeouts for creating, reading, and deleting the Dapr component.
+
+Type:
+
+```hcl
+object({
+    create = string
+    delete = string
+    read   = string
+  })
+```
+
+Default: `null`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The resource ID of the dapr component.
+
+## Modules
+
+No modules.
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/modules/dapr_component/_footer.md
+++ b/modules/dapr_component/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/modules/dapr_component/_header.md
+++ b/modules/dapr_component/_header.md
@@ -1,0 +1,18 @@
+# Azure Container Apps Managed Environment Dapr Components Module
+
+This module is used to create Dapr Components for a Container Apps Environment.
+
+## Usage
+
+```terraform
+module "avm-res-app-managedenvironment-daprcomponent" {
+  source = "Azure/avm-res-app-managedenvironment/azurerm//modules/dapr_component"
+
+  managed_environment = {
+    resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.App/managedEnvironments/myEnv"
+  }
+
+  component_type = "state.azure.blobstorage"
+  version        = "v1"
+}
+```

--- a/modules/dapr_component/main.tf
+++ b/modules/dapr_component/main.tf
@@ -1,0 +1,42 @@
+resource "azapi_resource" "this" {
+  type = "Microsoft.App/managedEnvironments/daprComponents@2024-03-01"
+  body = {
+    properties = {
+      componentType        = var.component_type
+      ignoreErrors         = var.ignore_errors
+      initTimeout          = var.init_timeout
+      secretStoreComponent = var.secret_store_component
+      scopes               = var.scopes
+      version              = var.dapr_component_version
+
+      metadata = var.metadata != null ? [
+        for m in var.metadata : {
+          name      = m.name
+          secretRef = m.secret_name
+          value     = m.value
+        }
+      ] : null
+
+      secrets = var.secret != null ? [
+        for s in var.secret : {
+          # identity    = s.identity
+          # keyVaultUrl = s.key_vault_secret_id
+          name  = s.name
+          value = s.value
+        }
+      ] : null
+    }
+  }
+  name      = var.name
+  parent_id = var.managed_environment.resource_id
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+    }
+  }
+}

--- a/modules/dapr_component/output.tf
+++ b/modules/dapr_component/output.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The resource ID of the dapr component."
+  value       = azapi_resource.this.id
+}

--- a/modules/dapr_component/terraform.tf
+++ b/modules/dapr_component/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.13, < 3"
+    }
+  }
+}

--- a/modules/dapr_component/variables.tf
+++ b/modules/dapr_component/variables.tf
@@ -1,0 +1,78 @@
+variable "component_type" {
+  type        = string
+  description = "The type of the Dapr component."
+}
+
+variable "managed_environment" {
+  type = object({
+    resource_id = string
+  })
+  description = "The Dapr component resource."
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the Dapr component."
+  nullable    = false
+}
+
+variable "dapr_component_version" {
+  type        = string
+  default     = null
+  description = "The version of the Dapr component."
+}
+
+variable "ignore_errors" {
+  type        = bool
+  default     = false
+  description = "Whether to ignore errors for the Dapr component."
+}
+
+variable "init_timeout" {
+  type        = string
+  default     = null
+  description = "The initialization timeout for the Dapr component."
+}
+
+variable "metadata" {
+  type = list(object({
+    name        = string
+    secret_name = string
+    value       = string
+  }))
+  default     = null
+  description = "The metadata for the Dapr component."
+}
+
+variable "scopes" {
+  type        = list(string)
+  default     = []
+  description = "The scopes for the Dapr component."
+}
+
+variable "secret" {
+  type = set(object({
+    # identity            = string
+    # key_vault_secret_id = string
+    name  = string
+    value = string
+  }))
+  default     = null
+  description = "The secrets for the Dapr component."
+}
+
+variable "secret_store_component" {
+  type        = string
+  default     = null
+  description = "The secret store component for the Dapr component."
+}
+
+variable "timeouts" {
+  type = object({
+    create = string
+    delete = string
+    read   = string
+  })
+  default     = null
+  description = "The timeouts for creating, reading, and deleting the Dapr component."
+}

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -1,0 +1,129 @@
+<!-- BEGIN_TF_DOCS -->
+# Azure Container Apps Managed Environment Storage Module
+
+This module is used to create storage for a Container Apps Environment.
+
+## Usage
+
+```terraform
+module "avm-res-app-managedenvironment-storage" {
+  source = "Azure/avm-res-app-managedenvironment/azurerm//modules/storage"
+
+  managed_environment = {
+    resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.App/managedEnvironments/myEnv"
+  }
+
+  account_name = azurerm_storage_account.this.name
+  share_name   = azurerm_storage_share.this.name
+  access_key   = azurerm_storage_account.this.primary_access_key
+  access_mode  = "ReadOnly"
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_azapi"></a> [azapi](#provider\_azapi) (>= 1.13, < 3)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.this](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_access_key"></a> [access\_key](#input\_access\_key)
+
+Description: The access key for the Azure file storage.
+
+Type: `string`
+
+### <a name="input_account_name"></a> [account\_name](#input\_account\_name)
+
+Description: The account name for the Azure file storage.
+
+Type: `string`
+
+### <a name="input_managed_environment"></a> [managed\_environment](#input\_managed\_environment)
+
+Description: The Dapr component resource.
+
+Type:
+
+```hcl
+object({
+    resource_id = string
+  })
+```
+
+### <a name="input_name"></a> [name](#input\_name)
+
+Description: The name of the storage resource.
+
+Type: `string`
+
+### <a name="input_share_name"></a> [share\_name](#input\_share\_name)
+
+Description: The share name for the Azure file storage.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_access_mode"></a> [access\_mode](#input\_access\_mode)
+
+Description: The access mode for the Azure file storage.
+
+Type: `string`
+
+Default: `"ReadOnly"`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: The timeouts for creating, reading, and deleting the storage resource.
+
+Type:
+
+```hcl
+object({
+    create = string
+    delete = string
+    read   = string
+  })
+```
+
+Default: `null`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The resource ID of the storage resource.
+
+## Modules
+
+No modules.
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/modules/storage/_footer.md
+++ b/modules/storage/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/modules/storage/_header.md
+++ b/modules/storage/_header.md
@@ -1,0 +1,20 @@
+# Azure Container Apps Managed Environment Storage Module
+
+This module is used to create storage for a Container Apps Environment.
+
+## Usage
+
+```terraform
+module "avm-res-app-managedenvironment-storage" {
+  source = "Azure/avm-res-app-managedenvironment/azurerm//modules/storage"
+
+  managed_environment = {
+    resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.App/managedEnvironments/myEnv"
+  }
+
+  account_name = azurerm_storage_account.this.name
+  share_name   = azurerm_storage_share.this.name
+  access_key   = azurerm_storage_account.this.primary_access_key
+  access_mode  = "ReadOnly"
+}
+```

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,26 @@
+resource "azapi_resource" "this" {
+  type = "Microsoft.App/managedEnvironments/storages@2024-03-01"
+  body = {
+    properties = {
+      azureFile = {
+        accessMode  = var.access_mode
+        accountKey  = var.access_key
+        accountName = var.account_name
+        shareName   = var.share_name
+      }
+    }
+  }
+  name                      = var.name
+  parent_id                 = var.managed_environment.resource_id
+  schema_validation_enabled = true
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+    }
+  }
+}

--- a/modules/storage/output.tf
+++ b/modules/storage/output.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The resource ID of the storage resource."
+  value       = azapi_resource.this.id
+}

--- a/modules/storage/terraform.tf
+++ b/modules/storage/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.13, < 3"
+    }
+  }
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,52 @@
+variable "access_key" {
+  type        = string
+  description = "The access key for the Azure file storage."
+  nullable    = false
+  sensitive   = true
+}
+
+variable "account_name" {
+  type        = string
+  description = "The account name for the Azure file storage."
+  nullable    = false
+}
+
+variable "managed_environment" {
+  type = object({
+    resource_id = string
+  })
+  description = "The Dapr component resource."
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the storage resource."
+}
+
+variable "share_name" {
+  type        = string
+  description = "The share name for the Azure file storage."
+  nullable    = false
+}
+
+variable "access_mode" {
+  type        = string
+  default     = "ReadOnly"
+  description = "The access mode for the Azure file storage."
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^(ReadOnly|ReadWrite)$", var.access_mode))
+    error_message = "The access mode must be either 'ReadOnly' or 'ReadWrite'."
+  }
+}
+
+variable "timeouts" {
+  type = object({
+    create = string
+    delete = string
+    read   = string
+  })
+  default     = null
+  description = "The timeouts for creating, reading, and deleting the storage resource."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,21 +3,9 @@ output "custom_domain_verification_id" {
   value       = try(azapi_resource.this_environment.output.properties.customDomainConfiguration.customDomainVerificationId, null)
 }
 
-output "dapr_component_metadata_secrets" {
-  description = "The metadata secrets output of the Dapr components."
-  sensitive   = true
-  value       = local.dapr_component_metadata_secrets_output
-}
-
-output "dapr_component_secrets" {
-  description = "The secrets output of the Dapr components."
-  sensitive   = true
-  value       = local.dapr_component_secrets_output
-}
-
-output "dapr_components" {
+output "dapr_component_resource_ids" {
   description = "A map of dapr components connected to this environment. The map key is the supplied input to var.dapr_components. The map value is the azurerm-formatted version of the entire dapr_components resource."
-  value       = local.dapr_component_outputs
+  value       = local.dapr_component_resource_ids
 }
 
 output "default_domain" {
@@ -70,13 +58,7 @@ output "static_ip_address" {
   value       = azapi_resource.this_environment.output.properties.staticIp
 }
 
-output "storage_access_keys" {
-  description = "The access key outputs of the storage resources."
-  sensitive   = true
-  value       = local.storage_access_key_outputs
-}
-
-output "storages" {
+output "storage_resource_ids" {
   description = "A map of storage shares connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire storage shares resource."
-  value       = local.storages_outputs
+  value       = local.storage_resource_ids
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "dapr_component_secrets" {
 }
 
 output "dapr_components" {
-  description = "A map of dapr components connected to this environment. The map key is the supplied input to var.storages. The map value is the azurerm-formatted version of the entire dapr_components resource."
+  description = "A map of dapr components connected to this environment. The map key is the supplied input to var.dapr_components. The map value is the azurerm-formatted version of the entire dapr_components resource."
   value       = local.dapr_component_outputs
 }
 


### PR DESCRIPTION
This includes a few missed lint checks.

I've also moved the `dapr_component` and `storage` sub-resources into sub-modules, mimicking recent changes from elsewhere.

As part of doing this I spotted I was exporting too many outputs (noting the anti-corruption layer concerns) - I've removed these and now it is just the compute attribute, the resource ID.

This change is now breaking - I've tested pre- and post- and there are example move blocks in the dapr & storage examples.

I need to update the parent PR this is going into with these notes..