### PR TITLE
fix: idempotency bug, and align outputs with AVM spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,30 +87,30 @@ Default: `null`
 
 ### <a name="input_dapr_components"></a> [dapr\_components](#input\_dapr\_components)
 
-Description: - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
-- `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
-- `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
-- `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
-- `scopes` - (Optional) A list of scopes to which this component applies.
-- `version` - (Required) The version of the component.
+Description:  - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
+ - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
+ - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
+ - `secret_store_component` - (Optional) Name of a Dapr component to retrieve component secrets from.
+ - `scopes` - (Optional) A list of scopes to which this component applies.
+ - `version` - (Required) The version of the component.
 
----
-`metadata` block supports the following:
-- `name` - (Required) The name of the Metadata configuration item.
-- `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
-- `value` - (Optional) The value for this metadata configuration item.
+ ---
+ `metadata` block supports the following:
+ - `name` - (Required) The name of the Metadata configuration item.
+ - `secret_name` - (Optional) The name of a secret specified in the `secrets` block that contains the value for this metadata configuration item.
+ - `value` - (Optional) The value for this metadata configuration item.
 
----
-`secret` block supports the following:
-- `name` - (Required) The Secret name.
-- `value` - (Required) The value for this secret.
+ ---
+ `secret` block supports the following:
+ - `name` - (Required) The Secret name.
+ - `value` - (Required) The value for this secret.
 
----
-`timeouts` block supports the following:
-- `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
-- `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
-- `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
-- `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Dapr Component.
+ ---
+ `timeouts` block supports the following:
+ - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Dapr Component.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
+ - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Dapr Component.
 
 Type:
 
@@ -295,17 +295,17 @@ Default: `{}`
 
 ### <a name="input_storages"></a> [storages](#input\_storages)
 
-Description: - `access_key` - (Required) The Storage Account Access Key.
-- `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
-- `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
-- `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
+Description:  - `access_key` - (Required) The Storage Account Access Key.
+ - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
+ - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
+ - `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 
----
-`timeouts` block supports the following:
-- `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
-- `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
-- `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
-- `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Storage.
+ ---
+ `timeouts` block supports the following:
+ - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Storage.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Storage.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
+ - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Storage.
 
 Type:
 
@@ -335,10 +335,10 @@ Default: `null`
 
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 
-Description: - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment.
-- `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment.
-- `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment.
-- `update` - (Defaults to 30 minutes) Used when updating the Container App Environment.
+Description:  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment.
+ - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment.
 
 Type:
 
@@ -347,6 +347,7 @@ object({
     create = optional(string)
     delete = optional(string)
     read   = optional(string)
+    update = optional(string)
   })
 ```
 
@@ -411,10 +412,6 @@ Description: The ID of the container app management environment resource.
 ### <a name="output_infrastructure_resource_group"></a> [infrastructure\_resource\_group](#output\_infrastructure\_resource\_group)
 
 Description: The infrastructure resource group of the Container Apps Managed Environment.
-
-### <a name="output_mtls_enabled"></a> [mtls\_enabled](#output\_mtls\_enabled)
-
-Description: Indicates if mTLS is enabled for the Container Apps Managed Environment.
 
 ### <a name="output_name"></a> [name](#output\_name)
 

--- a/examples/azurerm4_azapi2/README.md
+++ b/examples/azurerm4_azapi2/README.md
@@ -179,10 +179,6 @@ Description: The resource ID of the Container Apps Managed Environment.
 
 Description: The infrastructure resource group of the Container Apps Managed Environment.
 
-### <a name="output_mtls_enabled"></a> [mtls\_enabled](#output\_mtls\_enabled)
-
-Description: Indicates if mTLS is enabled for the Container Apps Managed Environment.
-
 ### <a name="output_name"></a> [name](#output\_name)
 
 Description: The name of the Container Apps Managed Environment.

--- a/examples/workload_profile/README.md
+++ b/examples/workload_profile/README.md
@@ -126,7 +126,35 @@ No optional inputs.
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_custom_domain_verification_id"></a> [custom\_domain\_verification\_id](#output\_custom\_domain\_verification\_id)
+
+Description: The custom domain verification ID of the Container Apps Managed Environment.
+
+### <a name="output_default_domain"></a> [default\_domain](#output\_default\_domain)
+
+Description: The default domain of the Container Apps Managed Environment.
+
+### <a name="output_docker_bridge_cidr"></a> [docker\_bridge\_cidr](#output\_docker\_bridge\_cidr)
+
+Description: The Docker bridge CIDR of the Container Apps Managed Environment.
+
+### <a name="output_infrastructure_resource_group"></a> [infrastructure\_resource\_group](#output\_infrastructure\_resource\_group)
+
+Description: The infrastructure resource group of the Container Apps Managed Environment.
+
+### <a name="output_platform_reserved_cidr"></a> [platform\_reserved\_cidr](#output\_platform\_reserved\_cidr)
+
+Description: The platform reserved CIDR of the Container Apps Managed Environment.
+
+### <a name="output_platform_reserved_dns_ip_address"></a> [platform\_reserved\_dns\_ip\_address](#output\_platform\_reserved\_dns\_ip\_address)
+
+Description: The platform reserved DNS IP address of the Container Apps Managed Environment.
+
+### <a name="output_static_ip_address"></a> [static\_ip\_address](#output\_static\_ip\_address)
+
+Description: The static IP address of the Container Apps Managed Environment.
 
 ## Modules
 

--- a/examples/workload_profile/output.tf
+++ b/examples/workload_profile/output.tf
@@ -1,18 +1,3 @@
-output "id" {
-  description = "The resource ID of the Container Apps Managed Environment."
-  value       = module.managedenvironment.id
-}
-
-output "resource_id" {
-  description = "The resource ID of the Container Apps Managed Environment."
-  value       = module.managedenvironment.resource_id
-}
-
-output "name" {
-  description = "The name of the Container Apps Managed Environment."
-  value       = module.managedenvironment.name
-}
-
 output "default_domain" {
   description = "The default domain of the Container Apps Managed Environment."
   value       = module.managedenvironment.default_domain
@@ -43,12 +28,8 @@ output "infrastructure_resource_group" {
   value       = module.managedenvironment.infrastructure_resource_group
 }
 
-output "dapr_component_resource_ids" {
-  description = "A map of dapr component resource IDs."
-  value       = module.managedenvironment.dapr_component_resource_ids
-}
-
-output "storage_resource_ids" {
-  description = "A map of dapr component resource IDs."
-  value       = module.managedenvironment.storage_resource_ids
+output "custom_domain_verification_id" {
+  description = "The custom domain verification ID of the Container Apps Managed Environment."
+  value       = try(azapi_resource.this_environment.output.properties.customDomainConfiguration.customDomainVerificationId, null)
+  sensitive   = true
 }

--- a/examples/workload_profile/output.tf
+++ b/examples/workload_profile/output.tf
@@ -30,6 +30,6 @@ output "infrastructure_resource_group" {
 
 output "custom_domain_verification_id" {
   description = "The custom domain verification ID of the Container Apps Managed Environment."
-  value       = try(azapi_resource.this_environment.output.properties.customDomainConfiguration.customDomainVerificationId, null)
+  value       = try(module.managedenvironment.custom_domain_verification_id, null)
   sensitive   = true
 }

--- a/examples/workload_profile_internal/README.md
+++ b/examples/workload_profile_internal/README.md
@@ -138,10 +138,6 @@ Description: The Docker bridge CIDR of the Container Apps Managed Environment.
 
 Description: The infrastructure resource group of the Container Apps Managed Environment.
 
-### <a name="output_mtls_enabled"></a> [mtls\_enabled](#output\_mtls\_enabled)
-
-Description: Indicates if mTLS is enabled for the Container Apps Managed Environment.
-
 ### <a name="output_platform_reserved_cidr"></a> [platform\_reserved\_cidr](#output\_platform\_reserved\_cidr)
 
 Description: The platform reserved CIDR of the Container Apps Managed Environment.

--- a/examples/workload_profile_internal/output.tf
+++ b/examples/workload_profile_internal/output.tf
@@ -27,8 +27,3 @@ output "infrastructure_resource_group" {
   description = "The infrastructure resource group of the Container Apps Managed Environment."
   value       = module.managedenvironment.infrastructure_resource_group
 }
-
-output "mtls_enabled" {
-  description = "Indicates if mTLS is enabled for the Container Apps Managed Environment."
-  value       = module.managedenvironment.mtls_enabled
-}

--- a/modules/dapr_component/README.md
+++ b/modules/dapr_component/README.md
@@ -147,15 +147,19 @@ Default: `null`
 
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 
-Description: The timeouts for creating, reading, and deleting the Dapr component.
+Description:  - `create` - (Defaults to 30 minutes) Used when creating the Dapr component.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Dapr component.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Dapr component.
+ - `update` - (Defaults to 30 minutes) Used when updating the Dapr component.
 
 Type:
 
 ```hcl
 object({
-    create = string
-    delete = string
-    read   = string
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
   })
 ```
 

--- a/modules/dapr_component/main.tf
+++ b/modules/dapr_component/main.tf
@@ -37,6 +37,7 @@ resource "azapi_resource" "this" {
       create = timeouts.value.create
       delete = timeouts.value.delete
       read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }

--- a/modules/dapr_component/variables.tf
+++ b/modules/dapr_component/variables.tf
@@ -69,10 +69,16 @@ variable "secret_store_component" {
 
 variable "timeouts" {
   type = object({
-    create = string
-    delete = string
-    read   = string
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
   })
   default     = null
-  description = "The timeouts for creating, reading, and deleting the Dapr component."
+  description = <<DESCRIPTION
+ - `create` - (Defaults to 30 minutes) Used when creating the Dapr component.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Dapr component.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Dapr component.
+ - `update` - (Defaults to 30 minutes) Used when updating the Dapr component.
+DESCRIPTION
 }

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -60,7 +60,7 @@ Type: `string`
 
 ### <a name="input_managed_environment"></a> [managed\_environment](#input\_managed\_environment)
 
-Description: The Dapr component resource.
+Description: The storage component resource.
 
 Type:
 
@@ -96,15 +96,19 @@ Default: `"ReadOnly"`
 
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 
-Description: The timeouts for creating, reading, and deleting the storage resource.
+Description:  - `create` - (Defaults to 30 minutes) Used when creating the storage component.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the storage component.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the storage component.
+ - `update` - (Defaults to 30 minutes) Used when updating the storage component.
 
 Type:
 
 ```hcl
 object({
-    create = string
-    delete = string
-    read   = string
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
   })
 ```
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -21,6 +21,7 @@ resource "azapi_resource" "this" {
       create = timeouts.value.create
       delete = timeouts.value.delete
       read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -15,7 +15,7 @@ variable "managed_environment" {
   type = object({
     resource_id = string
   })
-  description = "The Dapr component resource."
+  description = "The storage component resource."
 }
 
 variable "name" {
@@ -43,10 +43,16 @@ variable "access_mode" {
 
 variable "timeouts" {
   type = object({
-    create = string
-    delete = string
-    read   = string
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
   })
   default     = null
-  description = "The timeouts for creating, reading, and deleting the storage resource."
+  description = <<DESCRIPTION
+ - `create` - (Defaults to 30 minutes) Used when creating the storage component.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the storage component.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the storage component.
+ - `update` - (Defaults to 30 minutes) Used when updating the storage component.
+DESCRIPTION
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,6 @@
 output "custom_domain_verification_id" {
   description = "The custom domain verification ID of the Container Apps Managed Environment."
+  sensitive   = true
   value       = try(azapi_resource.this_environment.output.properties.customDomainConfiguration.customDomainVerificationId, null)
 }
 
@@ -26,11 +27,6 @@ output "id" {
 output "infrastructure_resource_group" {
   description = "The infrastructure resource group of the Container Apps Managed Environment."
   value       = try(azapi_resource.this_environment.output.properties.infrastructureResourceGroup, null)
-}
-
-output "mtls_enabled" {
-  description = "Indicates if mTLS is enabled for the Container Apps Managed Environment."
-  value       = try(azapi_resource.this_environment.output.properties.peerAuthentication.mtls.enabled, false)
 }
 
 output "name" {

--- a/variable.storage.tf
+++ b/variable.storage.tf
@@ -11,7 +11,7 @@ variable "storages" {
     }))
   }))
   default     = {}
-  description = <<-EOT
+  description = <<DESCRIPTION
  - `access_key` - (Required) The Storage Account Access Key.
  - `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
  - `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
@@ -24,6 +24,6 @@ variable "storages" {
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Storage.
  - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Storage.
 
-EOT
+DESCRIPTION
   nullable    = false
 }

--- a/variables.dapr_component.tf
+++ b/variables.dapr_component.tf
@@ -22,7 +22,7 @@ variable "dapr_components" {
     }))
   }))
   default     = {}
-  description = <<-EOT
+  description = <<DESCRIPTION
  - `component_type` - (Required) The Dapr Component Type. For example `state.azure.blobstorage`. Changing this forces a new resource to be created.
  - `ignore_errors` - (Optional) Should the Dapr sidecar to continue initialisation if the component fails to load. Defaults to `false`
  - `init_timeout` - (Optional) The timeout for component initialisation as a `ISO8601` formatted string. e.g. `5s`, `2h`, `1m`. Defaults to `5s`.
@@ -47,6 +47,6 @@ variable "dapr_components" {
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Dapr Component.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Dapr Component.
  - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Dapr Component.
-EOT
+DESCRIPTION
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -200,14 +200,15 @@ variable "timeouts" {
     create = optional(string)
     delete = optional(string)
     read   = optional(string)
+    update = optional(string)
   })
   default     = null
-  description = <<-EOT
+  description = <<DESCRIPTION
  - `create` - (Defaults to 30 minutes) Used when creating the Container App Environment.
  - `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment.
  - `update` - (Defaults to 30 minutes) Used when updating the Container App Environment.
-EOT
+DESCRIPTION
 }
 
 variable "workload_profile" {
@@ -218,7 +219,7 @@ variable "workload_profile" {
     workload_profile_type = string
   }))
   default     = []
-  description = <<-EOT
+  description = <<DESCRIPTION
 
 This lists the workload profiles that will be configured for the Managed Environment.
 This is in addition to the default Consumpion Plan workload profile.
@@ -227,7 +228,7 @@ This is in addition to the default Consumpion Plan workload profile.
  - `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.
  - `name` - (Required) The name of the workload profile.
  - `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
-EOT
+DESCRIPTION
   nullable    = false
 
   validation {


### PR DESCRIPTION
## Description

This addresses an idempotency bug in main, and aligns outputs with AVM specification requirements

**Breaking change:** All non-computed outputs have been dropped, as per the spec

-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [X] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [X] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
