### PR TITLE
fix: bug with workload profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Default: `true`
 
 ### <a name="input_infrastructure_resource_group_name"></a> [infrastructure\_resource\_group\_name](#input\_infrastructure\_resource\_group\_name)
 
-Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.   
+Description: Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.  
 If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.  
 If not specified, then one will be generated automatically, in the form `ME_<app_managed_environment_name>_<resource_group>_<location>`.
 
@@ -357,7 +357,7 @@ Default: `null`
 
 Description:   
 This lists the workload profiles that will be configured for the Managed Environment.  
-This is in addition to the default Consumpion Plan workload profile.
+This is in addition to the default Consumption Plan workload profile.
 
  - `maximum_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
  - `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
       id = sv.resource_id
     }
   }
-  workload_profiles = distinct(concat(
+  workload_profiles = toset(concat(
     [
       for wp in var.workload_profile : {
         name                = wp.name

--- a/locals.tf
+++ b/locals.tf
@@ -17,4 +17,22 @@ locals {
     for wp in var.workload_profile :
     wp.name == "Consumption" && wp.workload_profile_type == "Consumption"
   ], true)
+  workload_profiles = distinct(concat(
+    [
+      for wp in var.workload_profile : {
+        name                = wp.name
+        workloadProfileType = wp.workload_profile_type
+        minimumCount        = wp.minimum_count
+        maximumCount        = wp.maximum_count
+      }
+    ],
+    [
+      {
+        name                = "Consumption"
+        workloadProfileType = "Consumption"
+        minimumCount        = null
+        maximumCount        = null
+      }
+    ],
+  ))
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,11 +12,6 @@ locals {
       id = sv.resource_id
     }
   }
-  # this is used to mimic the behaviour of the azurerm provider
-  workload_profile_consumption_enabled = contains([
-    for wp in var.workload_profile :
-    wp.name == "Consumption" && wp.workload_profile_type == "Consumption"
-  ], true)
   workload_profiles = distinct(concat(
     [
       for wp in var.workload_profile : {

--- a/main.tf
+++ b/main.tf
@@ -25,21 +25,8 @@ resource "azapi_resource" "this_environment" {
         "internal"               = var.internal_load_balancer_enabled
         "infrastructureSubnetId" = var.infrastructure_subnet_id
       } : null
-      workloadProfiles = local.workload_profile_consumption_enabled ? setunion([
-        {
-          name                = "Consumption"
-          workloadProfileType = "Consumption"
-        }],
-        [for wp in var.workload_profile :
-          {
-            name                = wp.name
-            workloadProfileType = wp.workload_profile_type
-            minimumCount        = wp.minimum_count
-            maximumCount        = wp.maximum_count
-          } if wp.workload_profile_type != "Consumption"
-        ]
-      ) : null
-      zoneRedundant = var.zone_redundancy_enabled
+      workloadProfiles = local.workload_profiles
+      zoneRedundant    = var.zone_redundancy_enabled
       },
       # Only include the infrastructureResourceGroup property if it is set
       #

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "infrastructure_resource_group_name" {
   type        = string
   default     = null
   description = <<DESCRIPTION
-Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources. 
+Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources.
 If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.
 If not specified, then one will be generated automatically, in the form ``ME_<app_managed_environment_name>_<resource_group>_<location>``.
 DESCRIPTION
@@ -222,7 +222,7 @@ variable "workload_profile" {
   description = <<DESCRIPTION
 
 This lists the workload profiles that will be configured for the Managed Environment.
-This is in addition to the default Consumpion Plan workload profile.
+This is in addition to the default Consumption Plan workload profile.
 
  - `maximum_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
  - `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.


### PR DESCRIPTION
## Description

If specifying a workload profile, the previous `setunion()` function would result in a null output, probably as the types were not the same.

Switched to `toset()` and `concat()` and seems to work. Keeping the set type as this will make this change idempotent for callers.

fixes #117