### PR TITLE
chore: Update Terraform required_version for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Module to deploy Container Apps Managed Environments in Azure.
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 

--- a/examples/azurerm4_azapi2/README.md
+++ b/examples/azurerm4_azapi2/README.md
@@ -5,7 +5,7 @@ This deploys the module with all the supported subcomponents using AzureRM v4 an
 
 ```hcl
 terraform {
-  required_version = ">= 1.8.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v2 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -129,7 +129,7 @@ module "managedenvironment" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.8.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 2.0.0)
 

--- a/examples/azurerm4_azapi2/main.tf
+++ b/examples/azurerm4_azapi2/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v2 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/examples/dapr_component/README.md
+++ b/examples/dapr_component/README.md
@@ -5,7 +5,7 @@ This deploys the module with a environment-scoped dapr component.
 
 ```hcl
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -80,7 +80,7 @@ moved {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 

--- a/examples/dapr_component/main.tf
+++ b/examples/dapr_component/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -5,7 +5,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -68,7 +68,7 @@ module "managedenvironment" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/examples/storage_share/README.md
+++ b/examples/storage_share/README.md
@@ -5,7 +5,7 @@ This deploys the module with Container App Environment storage.
 
 ```hcl
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -96,7 +96,7 @@ moved {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 

--- a/examples/storage_share/main.tf
+++ b/examples/storage_share/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/examples/workload_profile/README.md
+++ b/examples/workload_profile/README.md
@@ -9,7 +9,7 @@ This will create an additional resource group for platform managed resources tha
 
 ```hcl
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -100,7 +100,7 @@ module "managedenvironment" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 

--- a/examples/workload_profile/main.tf
+++ b/examples/workload_profile/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/examples/workload_profile_internal/README.md
+++ b/examples/workload_profile_internal/README.md
@@ -5,7 +5,7 @@ This deploys a Container Apps Managed Environment using the consumption-based wo
 
 ```hcl
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers
@@ -98,7 +98,7 @@ module "managedenvironment" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 2.0.0)
 

--- a/examples/workload_profile_internal/main.tf
+++ b/examples/workload_profile_internal/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     # ignore this because we want to force the use of AzAPI v1 within the module without having it used in this example.
     # tflint-ignore: terraform_unused_required_providers

--- a/modules/dapr_component/README.md
+++ b/modules/dapr_component/README.md
@@ -23,7 +23,7 @@ module "avm-res-app-managedenvironment-daprcomponent" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 

--- a/modules/dapr_component/terraform.tf
+++ b/modules/dapr_component/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -25,7 +25,7 @@ module "avm-res-app-managedenvironment-storage" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 

--- a/modules/storage/terraform.tf
+++ b/modules/storage/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION
## Description

This PR updates the Terraform `required_version` constraint to ensure consistency across all AVM modules. The constraint has been set to `>= 1.9, < 2.0` to maintain compatibility and leverage the features available in Terraform versions within this range.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
