### PR TITLE
feature: optionally allow `parent_id` to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ object({
 
 Default: `{}`
 
+### <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id)
+
+Description: The parent resource ID for this resource. When provided, takes precedence over resource\_group\_name.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_peer_authentication_enabled"></a> [peer\_authentication\_enabled](#input\_peer\_authentication\_enabled)
 
 Description: Enable peer authentication (Mutual TLS).

--- a/locals.tf
+++ b/locals.tf
@@ -85,7 +85,11 @@ locals {
     length(ephemeral.azapi_resource_action.shared_keys) > 0 ?
     ephemeral.azapi_resource_action.shared_keys[0].output.primarySharedKey : var.log_analytics_workspace_primary_shared_key
   )
-  resource_group_id                  = "/subscriptions/${data.azapi_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
+  parent_id = var.parent_id != null ? var.parent_id : (
+    var.resource_group_name != null ?
+    "/subscriptions/${data.azapi_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}" :
+    null
+  )
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
   storage_resource_ids = {
     for sk, sv in module.storage :

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_resource" "this_environment" {
   location  = var.location
   name      = var.name
-  parent_id = local.resource_group_id
+  parent_id = local.parent_id
   type      = "Microsoft.App/managedEnvironments@2025-01-01"
   body = {
     properties = local.container_app_environment_properties

--- a/variables.tf
+++ b/variables.tf
@@ -203,6 +203,12 @@ variable "managed_identities" {
   nullable    = false
 }
 
+variable "parent_id" {
+  type        = string
+  default     = null
+  description = "The parent resource ID for this resource. When provided, takes precedence over resource_group_name."
+}
+
 variable "peer_authentication_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Description

Allow the `parent_id` to be set explicitly if desired.  If not falls back to current subscription & supplied `resource_group_name` (existing behaviour).

This follows the behaviour recommended by Matt in the linked issue.

Fixes #150
Closes #150
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
