### PR TITLE
Fix diagnostic settings drift when destination type is Dedicated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   target_resource_id             = azapi_resource.this_environment.id
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
-  log_analytics_destination_type = each.value.log_analytics_destination_type
+  log_analytics_destination_type = each.value.log_analytics_destination_type == "Dedicated" ? null : each.value.log_analytics_destination_type
   log_analytics_workspace_id     = each.value.workspace_resource_id
   partner_solution_id            = each.value.marketplace_partner_resource_id
   storage_account_id             = each.value.storage_account_resource_id


### PR DESCRIPTION
Fixes #160

This PR implements the workaround suggested in the issue discussion by @mikaharti.

For ACA Managed Environments, setting `log_analytics_destination_type` to `Dedicated` can result in perpetual Terraform state drift because the value is not persisted by Azure for this resource.

This change omits the field by setting it to `null` when the configured value is `Dedicated`, while preserving `AzureDiagnostics`.