### PR TITLE
consolidated triage 2026-05-28: fixes for #160, #157, #142

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,11 +160,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,14 @@ resource "azapi_resource" "this_environment" {
     "properties.vnetConfiguration.platformReservedCidr",
     "properties.vnetConfiguration.platformReservedDnsIP",
   ]
+  # Retry on transient errors raised against environments that have been
+  # scaled to zero ("sleeping"). The control plane returns
+  # ContainerAppEnvironmentDisabled until the environment finishes waking.
+  retry = {
+    error_message_regex = [
+      "ContainerAppEnvironmentDisabled",
+    ]
+  }
   schema_validation_enabled = true
   sensitive_body = {
     properties = {
@@ -81,14 +89,6 @@ resource "azapi_resource" "this_environment" {
       type         = identity.value.type
       identity_ids = identity.value.user_assigned_resource_ids
     }
-  }
-  # Retry on transient errors raised against environments that have been
-  # scaled to zero ("sleeping"). The control plane returns
-  # ContainerAppEnvironmentDisabled until the environment finishes waking.
-  retry = {
-    error_message_regex = [
-      "ContainerAppEnvironmentDisabled",
-    ]
   }
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,14 @@ resource "azapi_resource" "this_environment" {
       identity_ids = identity.value.user_assigned_resource_ids
     }
   }
+  # Retry on transient errors raised against environments that have been
+  # scaled to zero ("sleeping"). The control plane returns
+  # ContainerAppEnvironmentDisabled until the environment finishes waking.
+  retry = {
+    error_message_regex = [
+      "ContainerAppEnvironmentDisabled",
+    ]
+  }
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
 

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   target_resource_id             = azapi_resource.this_environment.id
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
-  log_analytics_destination_type = each.value.log_analytics_destination_type
+  log_analytics_destination_type = each.value.log_analytics_destination_type == "Dedicated" ? null : each.value.log_analytics_destination_type
   log_analytics_workspace_id     = each.value.workspace_resource_id
   partner_solution_id            = each.value.marketplace_partner_resource_id
   storage_account_id             = each.value.storage_account_resource_id


### PR DESCRIPTION
## Consolidated triage 2026-05-28

Single PR consolidating fixes for three open issues against v0.5.0. Supersedes WIP PRs #171, #172 (closed without merge) and folds in @AmeyParle's contribution from #164 (commit authorship preserved). #169 is effectively shipped in v0.5.0 (#170) and will be closed separately.

### Commits

| Commit | Author | Closes | Summary |
|---|---|---|---|
| `884ad9e` | @AmeyParle | #160 | diagnostic settings drift when `log_analytics_destination_type = "Dedicated"` (cherry-pick of #164, author preserved) |
| `d7b8ce8` | @segraef | #157 | rename deprecated `metric` block to `enabled_metric` (azurerm v4) |
| `d24c5ce` | @segraef | #142 | `azapi` retry block on `ContainerAppEnvironmentDisabled` for scaled-to-zero environments |

### Credits

Thanks to @AmeyParle for #164 — the original commit authorship is preserved in `884ad9e`.

Thanks to @SC-Tobias for #169 (`Consumption` in `workload_profile_type`). That change already shipped in v0.5.0 via #170 (see `variables.tf` line 715); #169 will be closed with that note — no functional change needed here.

### Verify-and-close after merge

The following issues were already addressed by v0.5.0 (#170) and will be closed with verification notes:
- #121 — `publicNetworkAccess` wired via `local.effective_public_network_access` (`locals.tf` line 192).
- #126 — `dynamicJsonColumns` mapped in `local.resource_body` (`locals.tf` line 127).
- #131 — subnet replace handled via `replace_triggers_refs` including `properties.vnetConfiguration.infrastructureSubnetId` (`main.tf` line 14).
- #141 — duplicate of #139, will be closed as duplicate.

### Out of scope

- #139 — OpenTofu 1.9 compatibility (ephemeral resources). Tracked separately; requires a `.tofu` shadow approach and is gated on OpenTofu 1.11 ephemeral support.

### Quality gates

- `terraform fmt`: clean (formatter ran via `./avm pre-commit`; resulting block ordering amended into `d24c5ce`).
- Target schema: `Microsoft.App/managedEnvironments@2025-10-02-preview`.
- Provider pins unchanged: `azurerm ~> 4.0`, `azapi ~> 2.7`, `modtm ~> 0.3`, `random ~> 3.5`.

